### PR TITLE
remove npm start and set minimize: true

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "login": "clasp login",
     "setup": "rm .clasp.json && clasp create --type sheets --title 'My React Project' --rootDir ./dist",
     "setup:use-id": "clasp setting scriptId",
-    "start": "webpack --mode development",
     "build": "webpack --mode production",
     "deploy": "npm run build && npx clasp push"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -165,6 +165,7 @@ const serverConfig = {
     ],
   },
   optimization: {
+    minimize: true,
     minimizer: [
       new TerserPlugin({
         sourceMap: true,


### PR DESCRIPTION
`webpack --mode development` does not actually work in script apps with the current setup due to issues with `gas-webpack-plugin` in development: https://github.com/fossamagna/gas-webpack-plugin/issues/135

- Removing `npm start` script (which runs `webpack --mode development`) since it's broken and to avoid confusion
- Adding `minimize: true` explicit flag on server webpack config just make it clear that this is editable.