### PR TITLE
Exclude "impl" files from being pushed during development

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -1,1 +1,2 @@
 main.js
+*-impl.html


### PR DESCRIPTION
`-impl.html` files cannot be pushed by clasp due to their size (10+MB each), so this change makes clasp ignore them, since they are not required for viewing changes during development (i.e. when running `npm run start`).

Related to #37