### PR TITLE
Fix: Allow jsDoc comments for custom functions

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -305,6 +305,9 @@ const serverConfig = {
           module: false,
           output: {
             beautify: true,
+            // support custom function autocompletion
+            // https://developers.google.com/apps-script/guides/sheets/functions
+            comments: /@customfunction/,
           },
         },
       }),


### PR DESCRIPTION
Allows jsDoc comments for custom sheets functions to remain in builds so that autocomplete works correctly. 

Fixes #64 