### PR TITLE
Add build in setup command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:integration": "jest --forceExit test/local-development.test",
     "test:integration:extended": "cross-env IS_EXTENDED=true jest --forceExit test/local-development.test",
     "login": "clasp login",
-    "setup": "rimraf .clasp.json && clasp create --type sheets --title \"My React Project\" --rootDir ./dist",
+    "setup": "npm run build; rimraf .clasp.json && clasp create --type sheets --title \"My React Project\" --rootDir ./dist",
     "open": "clasp open --addon",
     "setup:https": "mkdirp certs && mkcert -key-file ./certs/key.pem -cert-file ./certs/cert.pem localhost 127.0.0.1",
     "build:dev": "cross-env NODE_ENV=development webpack",


### PR DESCRIPTION
When using this repo for the first time and following README instructions, users won't have a build `dist` in the folder.
Running `nm run setup` will fail.
Adding `npm run build` in `npm run setup` makes it so you can "just follow the README instructions".