### PR TITLE
Update setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ Alternatively, you can use an existing Google Spreadsheet and Script file instea
 <details>
   <summary>See instructions here for using an existing project.</summary>
 
-You will need to update the `.clasp.json` file in the root of this project with the following three key/value pairs:
+You will need to update the `.clasp.json` file in the root of this project with the following three key/value pairs (see .clasp.json.SAMPLE for reference):
 
 ```json
 {
   "scriptId": "1PY037hPcy................................................",
   "parentId": ["1Df30......................................."],
-  "rootDir": "dist"
+  "rootDir": "./dist"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:integration": "jest --forceExit test/local-development.test",
     "test:integration:extended": "cross-env IS_EXTENDED=true jest --forceExit test/local-development.test",
     "login": "clasp login",
-    "setup": "rimraf .clasp.json && clasp create --type sheets --title \"My React Project\" --rootDir ./dist",
+    "setup": "rimraf .clasp.json && mkdirp dist && clasp create --type sheets --title \"My React Project\" --rootDir ./dist && mv ./dist/.clasp.json ./.clasp.json && rimraf dist",
     "open": "clasp open --addon",
     "setup:https": "mkdirp certs && mkcert -key-file ./certs/key.pem -cert-file ./certs/cert.pem localhost 127.0.0.1",
     "build:dev": "cross-env NODE_ENV=development webpack",


### PR DESCRIPTION
As of @google/clasp 2.4.1, running clasp create using the --rootDir flag creates the .clasp.json file inside this target rootDir, rather than in the root of this project, where the command is run.

The setup script is updated to take this into account in the least disruptive way to the file structure and organization of this project.