### PR TITLE
add: support source maps for tsx

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "types": ["gas-types-detailed"],
     "jsx": "react",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "sourceMap": true
   }
 }


### PR DESCRIPTION
As describe in this [babel-loader issue](https://github.com/babel/babel-loader/issues/820) this configuration is needed to see/debug original code in `devtools > soruces`

// `DummyComponent.tsx` in DevTools when `sourceMap: false`

```js
"use strict";
var __importDefault = (this && this.__importDefault) || function (mod) {
    return (mod && mod.__esModule) ? mod : { "default": mod };
};
exports.__esModule = true;
var react_1 = __importDefault(require("react"));
function DummyComponent() {
    return (react_1["default"].createElement("div", null,
        react_1["default"].createElement("h1", null, "hello world")));
}
exports["default"] = DummyComponent;

```

// `DummyComponent.tsx` in DevTools when `sourceMap: true`

```js
import React from 'react';

function DummyComponent() {
  return (
    <div>
      <h1>hello world</h1>
    </div>
  );
}

export default DummyComponent;
```