### PR TITLE
fix: setup script uses mv, which doesn't exist under Windows cmd.exe

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:integration:extended": "cross-env IS_EXTENDED=true jest --forceExit test/local-development.test",
     "test:integration:extended:ci-reporter": "cross-env IS_EXTENDED=true jest --forceExit || node test/utils/image-reporter-standalone.js",
     "login": "clasp login",
-    "setup": "rimraf .clasp.json && mkdirp dist && clasp create --type sheets --title \"My React Project\" --rootDir ./dist && mv ./dist/.clasp.json ./.clasp.json && rimraf dist",
+    "setup": "rimraf .clasp.json && mkdirp dist && clasp create --type sheets --title \"My React Project\" --rootDir ./dist && node -e \"require('fs').renameSync('./dist/.clasp.json', './.clasp.json')\" && rimraf dist",
     "open": "clasp open --addon",
     "push": "clasp push",
     "setup:https": "mkdirp certs && mkcert -key-file ./certs/key.pem -cert-file ./certs/cert.pem localhost 127.0.0.1",


### PR DESCRIPTION
Fixes #156.

`yarn run setup` fails on Windows with "'mv' is not recognized as an internal or external command" right after `clasp create` succeeds, leaving `.clasp.json` stuck in `dist/` instead of at the repo root where `clasp push`/`yarn deploy` expect it.

I saw in the issue thread that the Vite migration was expected to remove the need for `mv` but didn't fully resolve it, and that a Windows-only `move` workaround was suggested — that would trade the Windows breakage for breaking `mv` on macOS/Linux. This uses `fs.renameSync` instead, which works identically on every platform Node runs on. Kept it dependency-free (no new package) since it's a one-line rename and Node is already a hard prerequisite here.

### Test plan
- Reproduced the exact cmd.exe failure, confirmed the fix works identically under cmd.exe and POSIX shells.
- `npm run build` still succeeds end to end.

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.